### PR TITLE
Improve the implementation of deleting multiple objects

### DIFF
--- a/lib/qingstor/sdk/request/request.rb
+++ b/lib/qingstor/sdk/request/request.rb
@@ -66,7 +66,7 @@ module QingStor
         self.request_url = "#{input[:request_endpoint]}#{Signer.escape input[:request_uri]}#{query_string}"
 
         request      = new_http_request input[:request_method], request_url
-        request.body = build_request_body input[:request_body], input[:request_elements]
+        request.body = input[:request_body]
         input[:request_headers].each { |k, v| request[k.to_s] = v }
 
         self.http_request = request
@@ -99,18 +99,6 @@ module QingStor
         end
         unless !input[:config][:secret_access_key].nil? && !input[:config][:secret_access_key].empty?
           raise SDKError, 'secret access key not provided'
-        end
-      end
-
-      def build_request_body(request_body, request_elements)
-        if request_body
-          request_body
-        elsif request_elements
-          unless request_elements.empty?
-            json_body = JSON.generate request_elements
-            Logger.info "QingStor request json: [#{input[:id]}] #{json_body}"
-            json_body
-          end
         end
       end
 

--- a/lib/qingstor/sdk/service/bucket.rb
+++ b/lib/qingstor/sdk/service/bucket.rb
@@ -46,9 +46,7 @@ module QingStor
           },
           request_elements: {
           },
-
           request_body:     nil,
-
           status_code:      [
             204, # Bucket deleted
           ],
@@ -86,9 +84,7 @@ module QingStor
           },
           request_elements: {
           },
-
           request_body:     nil,
-
           status_code:      [
             200, # OK
           ],
@@ -126,9 +122,7 @@ module QingStor
           },
           request_elements: {
           },
-
           request_body:     nil,
-
           status_code:      [
             204, # No content
           ],
@@ -166,9 +160,7 @@ module QingStor
           },
           request_elements: {
           },
-
           request_body:     nil,
-
           status_code:      [
             204, # No content
           ],
@@ -188,14 +180,14 @@ module QingStor
 
       # delete_multiple_objects: Delete multiple objects from the bucket.
       # Documentation URL: https://docs.qingcloud.com/qingstor/api/bucket/delete_multiple.html
-      def delete_multiple_objects(content_md5: '', objects: [],
+      def delete_multiple_objects(objects: [],
                                   quiet: nil)
-        request = delete_multiple_objects_request content_md5: content_md5, objects: objects,
-          quiet: quiet
+        request = delete_multiple_objects_request objects: objects,
+                                                  quiet:   quiet
         request.send
       end
 
-      def delete_multiple_objects_request(content_md5: '', objects: [],
+      def delete_multiple_objects_request(objects: [],
                                           quiet: nil)
         input = {
           config:           config,
@@ -206,15 +198,12 @@ module QingStor
           request_params:   {
           },
           request_headers:  {
-            'Content-MD5' => content_md5,
           },
           request_elements: {
             'objects' => objects,
             'quiet'   => quiet,
           },
-
           request_body:     nil,
-
           status_code:      [
             200, # OK
           ],
@@ -228,10 +217,6 @@ module QingStor
 
       def delete_multiple_objects_input_validate(input)
         input.deep_stringify_keys!
-
-        unless !input['request_headers']['Content-MD5'].nil? && !input['request_headers']['Content-MD5'].to_s.empty?
-          raise ParameterRequiredError.new('Content-MD5', 'DeleteMultipleObjectsInput')
-        end
 
         unless !input['request_elements']['objects'].nil? && !input['request_elements']['objects'].to_s.empty?
           raise ParameterRequiredError.new('objects', 'DeleteMultipleObjectsInput')
@@ -263,9 +248,7 @@ module QingStor
           },
           request_elements: {
           },
-
           request_body:     nil,
-
           status_code:      [
             200, # OK
           ],
@@ -303,9 +286,7 @@ module QingStor
           },
           request_elements: {
           },
-
           request_body:     nil,
-
           status_code:      [
             200, # OK
           ],
@@ -343,9 +324,7 @@ module QingStor
           },
           request_elements: {
           },
-
           request_body:     nil,
-
           status_code:      [
             200, # OK
           ],
@@ -383,9 +362,7 @@ module QingStor
           },
           request_elements: {
           },
-
           request_body:     nil,
-
           status_code:      [
             200, # OK
           ],
@@ -423,9 +400,7 @@ module QingStor
           },
           request_elements: {
           },
-
           request_body:     nil,
-
           status_code:      [
             200, # OK
           ],
@@ -463,9 +438,7 @@ module QingStor
           },
           request_elements: {
           },
-
           request_body:     nil,
-
           status_code:      [
             200, # OK
           ],
@@ -516,9 +489,7 @@ module QingStor
           },
           request_elements: {
           },
-
           request_body:     nil,
-
           status_code:      [
             200, # OK
           ],
@@ -556,9 +527,7 @@ module QingStor
           },
           request_elements: {
           },
-
           request_body:     nil,
-
           status_code:      [
             201, # Bucket created
           ],
@@ -597,9 +566,7 @@ module QingStor
           request_elements: {
             'acl' => acl,
           },
-
           request_body:     nil,
-
           status_code:      [
             200, # OK
           ],
@@ -678,9 +645,7 @@ module QingStor
           request_elements: {
             'cors_rules' => cors_rules,
           },
-
           request_body:     nil,
-
           status_code:      [
             200, # OK
           ],
@@ -733,9 +698,7 @@ module QingStor
           request_elements: {
             'source_site' => source_site,
           },
-
           request_body:     nil,
-
           status_code:      [
             200, # OK
           ],
@@ -778,9 +741,7 @@ module QingStor
           request_elements: {
             'statement' => statement,
           },
-
           request_body:     nil,
-
           status_code:      [
             200, # OK
           ],

--- a/lib/qingstor/sdk/service/object.rb
+++ b/lib/qingstor/sdk/service/object.rb
@@ -43,9 +43,7 @@ module QingStor
           },
           request_elements: {
           },
-
           request_body:     nil,
-
           status_code:      [
             204, # Object multipart deleted
           ],
@@ -103,9 +101,7 @@ module QingStor
           request_elements: {
             'object_parts' => object_parts,
           },
-
           request_body:     nil,
-
           status_code:      [
             201, # Object created
           ],
@@ -154,9 +150,7 @@ module QingStor
           },
           request_elements: {
           },
-
           request_body:     nil,
-
           status_code:      [
             204, # Object deleted
           ],
@@ -224,9 +218,7 @@ module QingStor
           },
           request_elements: {
           },
-
           request_body:     nil,
-
           status_code:      [
             200, # OK
             206,  # Partial content
@@ -293,9 +285,7 @@ module QingStor
           },
           request_elements: {
           },
-
           request_body:     nil,
-
           status_code:      [
             200, # OK
           ],
@@ -347,9 +337,7 @@ module QingStor
           },
           request_elements: {
           },
-
           request_body:     nil,
-
           status_code:      [
             200, # OK
           ],
@@ -397,9 +385,7 @@ module QingStor
           },
           request_elements: {
           },
-
           request_body:     nil,
-
           status_code:      [
             200, # OK
           ],
@@ -451,9 +437,7 @@ module QingStor
           },
           request_elements: {
           },
-
           request_body:     nil,
-
           status_code:      [
             200, # OK
           ],
@@ -572,9 +556,7 @@ module QingStor
           },
           request_elements: {
           },
-
           request_body:     body,
-
           status_code:      [
             201, # Object created
           ],
@@ -638,9 +620,7 @@ module QingStor
           },
           request_elements: {
           },
-
           request_body:     body,
-
           status_code:      [
             201, # Object multipart created
           ],

--- a/lib/qingstor/sdk/service/qingstor.rb
+++ b/lib/qingstor/sdk/service/qingstor.rb
@@ -48,9 +48,7 @@ module QingStor
           },
           request_elements: {
           },
-
           request_body:     nil,
-
           status_code:      [
             200, # OK
           ],

--- a/template/shared.tmpl
+++ b/template/shared.tmpl
@@ -8,25 +8,29 @@
 {{end}}
 
 {{define "CustomizedTypeRequestParams"}}
-  {{- $customizedType := . -}}
+  {{- $customizedType := index . 0 -}}
+  {{- $operationName := index . 1 -}}
+
   {{- $firstPropertyID := $customizedType | firstPropertyIDInCustomizedType -}}
   {{- range $_, $property := $customizedType.Properties -}}
-    {{- if ne $property.ID $firstPropertyID -}},
-    {{end -}}
-    {{- if eq $property.Type "string" -}}
-      {{$property.ID | snakeCase}}: ''
-    {{- else if eq $property.Type "timestamp" -}}
-      {{$property.ID | snakeCase}}: ''
-    {{- else if eq $property.Type "array" -}}
-      {{$property.ID | snakeCase}}: []
-    {{- else if eq $property.Type "object" -}}
-      {{$property.ID | snakeCase}}: []
-    {{- else if eq $property.Type "map" -}}
-      {{$property.ID | snakeCase}}: []
-    {{- else if eq $property.Type "any" -}}
-      {{$property.ID | snakeCase}}: []
-    {{- else -}}
-      {{$property.ID | snakeCase}}: nil
+    {{- if or (ne $operationName "Delete Multiple Objects") (ne $property.ID "Content-MD5") -}}
+      {{- if ne $property.ID $firstPropertyID -}},
+      {{end -}}
+      {{- if eq $property.Type "string" -}}
+        {{$property.ID | snakeCase}}: ''
+      {{- else if eq $property.Type "timestamp" -}}
+        {{$property.ID | snakeCase}}: ''
+      {{- else if eq $property.Type "array" -}}
+        {{$property.ID | snakeCase}}: []
+      {{- else if eq $property.Type "object" -}}
+        {{$property.ID | snakeCase}}: []
+      {{- else if eq $property.Type "map" -}}
+        {{$property.ID | snakeCase}}: []
+      {{- else if eq $property.Type "any" -}}
+        {{$property.ID | snakeCase}}: []
+      {{- else -}}
+        {{$property.ID | snakeCase}}: nil
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 {{end}}
@@ -35,8 +39,10 @@
   {{- $service := index . 0 -}}
   {{- $operation := index . 1 -}}
 
+  {{- $ignoreHeaders := eq $operation.Name "Delete Multiple Objects" -}}
+
   {{- $hasParams := gt (len $operation.Request.Params.Properties) 0 -}}
-  {{- $hasHeaders := gt (len $operation.Request.Headers.Properties) 0 -}}
+  {{- $hasHeaders := and (gt (len $operation.Request.Headers.Properties) 0) (not $ignoreHeaders) -}}
   {{- $hasElements := gt (len $operation.Request.Elements.Properties) 0 -}}
 
   {{- if eq $service.Name "Object" -}}
@@ -44,11 +50,11 @@
     {{- if or $hasParams $hasHeaders $hasElements -}},{{- end -}}
   {{- end -}}
 
-  {{- template "CustomizedTypeRequestParams" $operation.Request.Params -}}
+  {{- template "CustomizedTypeRequestParams" passThrough $operation.Request.Params $operation.Name -}}
   {{- if and $hasParams $hasHeaders -}},{{end}}
-  {{- template "CustomizedTypeRequestParams" $operation.Request.Headers -}}
+  {{- template "CustomizedTypeRequestParams" passThrough $operation.Request.Headers $operation.Name -}}
   {{- if and (or $hasParams $hasHeaders) $hasElements -}},{{end}}
-  {{- template "CustomizedTypeRequestParams" $operation.Request.Elements -}}
+  {{- template "CustomizedTypeRequestParams" passThrough $operation.Request.Elements $operation.Name -}}
 
   {{- if eq $operation.Request.Body.Type "string" -}}
     {{- if or $hasParams $hasHeaders $hasElements -}},{{end}}
@@ -63,8 +69,10 @@
   {{- $service := index . 0 -}}
   {{- $operation := index . 1 -}}
 
+  {{- $ignoreHeaders := eq $operation.Name "Delete Multiple Objects" -}}
+
   {{- $hasParams := gt (len $operation.Request.Params.Properties) 0 -}}
-  {{- $hasHeaders := gt (len $operation.Request.Headers.Properties) 0 -}}
+  {{- $hasHeaders := and (gt (len $operation.Request.Headers.Properties) 0) (not $ignoreHeaders) -}}
   {{- $hasElements := gt (len $operation.Request.Elements.Properties) 0 -}}
 
   {{- if eq $service.Name "Object" -}}
@@ -79,13 +87,15 @@
     {{$property.ID | snakeCase}}:{{$property.ID | snakeCase}}
   {{- end -}}
 
-  {{- if and $hasParams $hasHeaders -}},{{end}}
+  {{- if not $ignoreHeaders -}}
+    {{- if and $hasParams $hasHeaders -}},{{end}}
 
-  {{- $firstID := $operation.Request.Headers | firstPropertyIDInCustomizedType -}}
-  {{- range $_, $property := $operation.Request.Headers.Properties -}}
+    {{- $firstID := $operation.Request.Headers | firstPropertyIDInCustomizedType -}}
+    {{- range $_, $property := $operation.Request.Headers.Properties -}}
     {{- if ne $property.ID $firstID -}},
     {{end -}}
     {{$property.ID | snakeCase}}:{{$property.ID | snakeCase}}
+    {{- end -}}
   {{- end -}}
 
   {{- if and (or $hasParams $hasHeaders) $hasElements -}},{{end}}
@@ -150,7 +160,9 @@
         },
         request_headers: {
           {{range $_, $property := $operation.Request.Headers.Properties -}}
-            '{{$property.Name}}'=> {{$property.ID | snakeCase}},
+            {{- if or (ne $operation.Name "Delete Multiple Objects") (ne $property.ID "Content-MD5") -}}
+              '{{$property.Name}}'=> {{$property.ID | snakeCase}},
+            {{end -}}
           {{end -}}
         },
         request_elements: {
@@ -158,14 +170,14 @@
             '{{$property.Name}}'=> {{$property.ID | snakeCase}},
           {{end -}}
         },
-        {{if eq $operation.Request.Body.Type "string"}}
+        {{- if eq $operation.Request.Body.Type "string"}}
           request_body: body,
         {{else if eq $operation.Request.Body.Type "binary"}}
           request_body: body,
         {{else}}
           request_body: nil,
         {{end}}
-        {{- if $operation.Response.StatusCodes}}
+        {{- if $operation.Response.StatusCodes -}}
           status_code: [
             {{range $statusCodeNumber, $statusCode := $operation.Response.StatusCodes -}}
               {{$statusCodeNumber}},
@@ -257,10 +269,16 @@
   def {{$operation.ID | snakeCase}}_input_validate(input)
     input.deep_stringify_keys!
 
+    {{- $ignoreHeaders := eq $operation.Name "Delete Multiple Objects" -}}
+
     {{$x := passThrough "input['request_params']" $request.Params $customizedTypes}}
     {{template "RenderCustomizedTypeValidation" $x}}
-    {{$x := passThrough "input['request_headers']" $request.Headers $customizedTypes}}
-    {{template "RenderCustomizedTypeValidation" $x}}
+
+    {{if not $ignoreHeaders}}
+      {{$x := passThrough "input['request_headers']" $request.Headers $customizedTypes}}
+      {{template "RenderCustomizedTypeValidation" $x}}
+    {{end}}
+
     {{$x := passThrough "input['request_elements']" $request.Elements $customizedTypes}}
     {{template "RenderCustomizedTypeValidation" $x}}
   end

--- a/test/bucket.rb
+++ b/test/bucket.rb
@@ -15,8 +15,6 @@
 #  +-------------------------------------------------------------------------
 
 require 'json'
-require 'digest'
-require 'base64'
 
 require 'qingstor/sdk'
 
@@ -95,12 +93,8 @@ When(/^delete multiple objects:$/) do |delete_objects_string|
   raise unless output_2[:status_code] == 201
 
   delete_objects = JSON.parse delete_objects_string
-  md5 = Base64.encode64(Digest::MD5.digest(JSON.generate(
-                                             objects: delete_objects['objects'],
-                                             quiet:   delete_objects['quiet'],
-  ))).strip
   @delete_multiple_objects_output = bucket.delete_multiple_objects(
-    objects: delete_objects['objects'], quiet: delete_objects['quiet'], content_md5: md5,
+    objects: delete_objects['objects'], quiet: delete_objects['quiet'],
   )
 end
 


### PR DESCRIPTION
Remove the "content_md5" parameter in "delete_multiple_objects", and calculate
the Content-MD5 of the request body before sending request.

Signed-off-by: Jingwen Peng <pengsrc@yunify.com>