### PR TITLE
Reverse fix of empty map in template, should not compact empty hash when sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ All notable changes to QingStor SDK for Ruby will be documented here.
 - Modify content-type check for application/json. (#21)
 - Fix sub-resources not be recognized when generate signature. (#25)
 - Fix meta data not work as intended. (#26)
+- Reverse fix of empty map in template, should not compact empty hash when sign. (#28)
 
 ### [v2.2.3] - 2017-03-28
 

--- a/lib/qingstor/sdk/service/object.rb
+++ b/lib/qingstor/sdk/service/object.rb
@@ -482,7 +482,7 @@ module QingStor
                                     x_qs_encryption_customer_algorithm: '',
                                     x_qs_encryption_customer_key: '',
                                     x_qs_encryption_customer_key_md5: '',
-                                    x_qs_meta_data: {},
+                                    x_qs_meta_data: [],
                                     x_qs_storage_class: '')
         request = initiate_multipart_upload_request object_key, content_type:                       content_type,
                                                                 x_qs_encryption_customer_algorithm: x_qs_encryption_customer_algorithm,
@@ -497,7 +497,7 @@ module QingStor
                                             x_qs_encryption_customer_algorithm: '',
                                             x_qs_encryption_customer_key: '',
                                             x_qs_encryption_customer_key_md5: '',
-                                            x_qs_meta_data: {},
+                                            x_qs_meta_data: [],
                                             x_qs_storage_class: '')
         properties[:'object-key'] = object_key
         input = {
@@ -681,7 +681,7 @@ module QingStor
                      x_qs_encryption_customer_key_md5: '',
                      x_qs_fetch_if_unmodified_since: '',
                      x_qs_fetch_source: '',
-                     x_qs_meta_data: {},
+                     x_qs_meta_data: [],
                      x_qs_move_source: '',
                      x_qs_storage_class: '',
                      body: nil)
@@ -730,7 +730,7 @@ module QingStor
                              x_qs_encryption_customer_key_md5: '',
                              x_qs_fetch_if_unmodified_since: '',
                              x_qs_fetch_source: '',
-                             x_qs_meta_data: {},
+                             x_qs_meta_data: [],
                              x_qs_move_source: '',
                              x_qs_storage_class: '',
                              body: nil)

--- a/template/shared.tmpl
+++ b/template/shared.tmpl
@@ -25,7 +25,7 @@
       {{- else if eq $property.Type "object" -}}
         {{$property.ID | snakeCase}}: []
       {{- else if eq $property.Type "map" -}}
-        {{$property.ID | snakeCase}}: {}
+        {{$property.ID | snakeCase}}: []
       {{- else if eq $property.Type "any" -}}
         {{$property.ID | snakeCase}}: []
       {{- else -}}


### PR DESCRIPTION
If compact all empty hash, it will also delete `request_headers` and `request_params` when preprocess the input.
So we need to use another data struct to demonstrate empty map, here is `[]`. 